### PR TITLE
Update RedHat family install tasks to include installation of GPG key

### DIFF
--- a/tasks/install/RedHat.yml
+++ b/tasks/install/RedHat.yml
@@ -1,4 +1,8 @@
 ---
+- name: Install BigFix GPG Key
+  rpm_key:
+    state: present
+    key: http://software.bigfix.com/download/bes/95/RPM-GPG-KEY-BigFix-9-V2
 
 - name: Install BigFix Client
   yum:


### PR DESCRIPTION
* Updated the install tasks for RedHat families to import the BigFix GPG key (http://software.bigfix.com/download/bes/95/RPM-GPG-KEY-BigFix-9-V2).