### PR TITLE
Fix when condition for bigfix_update

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
   register: bigfix_installed
 
 - include: install.yml
-  when: not bigfix_installed.stat.exists or not bigfix_update is defined
+  when: not bigfix_installed.stat.exists or bigfix_update is defined
 
 - name: Download masthead from BigFix Server
   get_url:


### PR DESCRIPTION
As `bigfix_update` is not set by default, therefore having `when: not bigfix_update is defined` will constantly re-install the client even when is not requested.