### PR TITLE
Allow the detected OS to be re-mapped #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Set the version/development kit of Java to install, along with any other necessa
     # On AIX
     bigfix_client_service_name: SBESClientd
 
+## Overriding a detect OS installer
+
+You can now set `bigfix_client_override_vars` as a mapping from one detect os to another.
+
+```yaml
+---
+bigfix_client_override_vars:
+  Debian-12-x86_64: Debian-11-x86_64
+```
+
 ## Re-install or update
 
 You may use `bigfix_update: true` to have the client be re-installed. Useful for new versions

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,14 @@
 ---
 bigfix_client_conf_dir: /etc/opt/BESClient
-bigfix_client_server_name: bigfix.example.com
+bigfix_client_server_name: bigfix.local
 bigfix_client_server_port: 52311
 bigfix_client_service_name: besclient
+
+# Allows the detect os distribution/family to be remapped
+bigfix_client_override_vars: {}
+
+##########
+#### NOTE: These change the behavior of the tasks and shouldn't need to be set.
+##########
+bigfix_client_distribution: "{{ ansible_distribution }}-{{ ansible_distribution_version.split('.')[0] }}-{{ ansible_architecture }}"
+bigfix_client_os_family: "{{ ansible_os_family }}-{{ ansible_distribution_version.split('.')[0] }}-{{ ansible_architecture }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 dependencies: []
 galaxy_info:
+  namespace: outsideopen
   role_name: bigfix_client
   author: David Lundgren
   company: Outside Open

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Ensure configuration directory exists
   file:
     name: "{{ bigfix_client_conf_dir }}"
@@ -11,7 +10,8 @@
     dest: "/tmp/{{ bigfix_client_file_dest }}"
     checksum: "sha256:{{ bigfix_client_file_sum }}"
 
-- include: "install/{{ ansible_os_family }}.yml"
+- name: Include the OS specific installation procedure
+  include_tasks: "install/{{ ansible_os_family }}.yml"
 
 - name: Record the installation
   file:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,13 @@
 ---
-
-- name: Load OS specific vars
-  include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_version.split('.')[0] }}-{{ ansible_architecture }}.yml"
-
-- name: Load OS Family specific vars
-  when: bigfix_client_file_sum is not defined
-  include_vars: "{{ ansible_os_family }}-{{ ansible_distribution_version.split('.')[0] }}-{{ ansible_architecture }}.yml"
+- name: Load vars based on OS distribution or family
+  include_vars: "{{ lookup('ansible.builtin.first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ bigfix_client_override_vars[bigfix_client_distribution] | default(bigfix_client_distribution) }}.yml"
+        - "{{ bigfix_client_override_vars[bigfix_client_os_family] | default(bigfix_client_os_family) }}.yml"
+      paths:
+        - 'vars'
 
 - name: Failing due to undetermined OS
   fail:
@@ -17,10 +19,11 @@
     path: "{{ bigfix_client_conf_dir }}/.ansible_installed"
   register: bigfix_installed
 
-- include: install.yml
+- name: Run the BigFix OS install
+  include_tasks: install.yml
   when: not bigfix_installed.stat.exists or bigfix_update is defined
 
-- name: determine if masthead already exists
+- name: Determine if masthead already exists
   stat:
     path: "{{ bigfix_client_conf_dir }}/actionsite.afxm"
   register: masthead_file


### PR DESCRIPTION
This also switches from `include` to `include_tasks` as the latest Ansible version removed `include` all together.

This allows for the detected OS to be mapped using the following syntax, while verbose it's cleaner than adding a map to the `generate.py` script.
```yaml
bigfix_client_override_vars:
  Debian-12-x86_64: Debian-11-x86_64
```